### PR TITLE
Add the `tzdata` package to the final build image

### DIFF
--- a/_posts/2018-05-15-developing-deploying-vapor-docker.markdown
+++ b/_posts/2018-05-15-developing-deploying-vapor-docker.markdown
@@ -276,7 +276,7 @@ RUN swift build -c release && mv `swift build -c release --show-bin-path` /build
 FROM ubuntu:16.04
 RUN apt-get -qq update && apt-get install -y \
   libicu55 libxml2 libbsd0 libcurl3 libatomic1 \
-  libmysqlclient20 \
+  libmysqlclient20 tzdata \
   && rm -r /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/bin/Run .


### PR DESCRIPTION
Without it, `DateFormatter` and `ISO8601DateFormatter` will hard crash your application when encoding / decoding structs containing `Date`.